### PR TITLE
Add HA live broker profile with multi-port sniffing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     restart: unless-stopped
     network_mode: host
     privileged: true
-    volumes:
-      - /var/log:/var/log
     devices:
       - "/dev/serial/by-path:/dev/serial/by-path"
       # Optional explicit device nodes (uncomment if needed)
@@ -17,9 +15,11 @@ services:
       growatt-broker
       --inverter ${INV_DEV}
       --shine ${SHINE_DEV}
-      --baud ${BAUD:-9600}
-      --bytes ${BYTES:-8E1}
+      --baud ${BAUD:-115200}
+      --bytes ${BYTES:-8N1}
       --tcp ${TCP_BIND:-0.0.0.0:5020}
+      --tcp-alt ${TCP_ALT_BIND:-0.0.0.0:5021}
+      --sniff ${SNIFF_BIND:-0.0.0.0:5700}
       --min-period ${MIN_PERIOD:-1.0}
       --rtimeout ${RTIMEOUT:-1.5}
-      --log ${LOG_PATH:-/var/log/growatt_broker.jsonl}
+      --log ${LOG_PATH:--}

--- a/docs/ha_live_setup.md
+++ b/docs/ha_live_setup.md
@@ -1,0 +1,84 @@
+# Home Assistant live deployment profile
+
+This guide captures the exact configuration used to run the live Growatt broker on a Home Assistant (HA) installation while
+simultaneously serving Home Assistant, a ShineWiFi dongle, and a developer laptop.
+
+## Goals
+
+* Share one inverter between Home Assistant (Modbus TCP) and the physical ShineWiFi dongle.
+* Offer a second Modbus TCP endpoint so that ad-hoc tools or a devcontainer-based HA instance can talk to the inverter without
+disturbing the production HA system.
+* Relay every Modbus RTU frame to a read-only TCP stream so that a laptop can sniff traffic in real time for debugging or
+register discovery.
+* Avoid persistent log files on the HA SSD while still giving live observability through the sniff stream.
+
+## Serial wiring and parameters
+
+Both serial legs (inverter and ShineWiFi) are configured at **115200 baud, 8 data bits, no parity, 1 stop bit (115k2 8N1)**. If
+the dongle is unplugged the broker will automatically retry and begin forwarding requests again once it reappears.
+
+You can discover the device paths from the HA OS shell with:
+
+```bash
+ls -l /dev/serial/by-path
+```
+
+Record the inverter and ShineWiFi entries and place them in the `.env` file described below.
+
+## Compose configuration
+
+1. Copy this repository to `/mnt/data/supervisor/homeassistant/growatt-rtu-broker` on the HA host.
+2. Create an `.env` file in that directory with the following content (replace the serial device paths with the values from your
+   system):
+
+   ```ini
+   INV_DEV=/dev/serial/by-path/pci-0000:01:00.0-usb-0:1:1.0-port0
+   SHINE_DEV=/dev/serial/by-path/pci-0000:01:00.0-usb-0:2:1.0-port0
+   BAUD=115200
+   BYTES=8N1
+   TCP_BIND=0.0.0.0:5020
+   TCP_ALT_BIND=0.0.0.0:5021
+   SNIFF_BIND=0.0.0.0:5700
+   MIN_PERIOD=1.0
+   RTIMEOUT=1.5
+   LOG_PATH=-
+   ```
+
+   * `TCP_BIND` feeds the production Home Assistant instance.
+   * `TCP_ALT_BIND` is reserved for your laptop or devcontainer tooling.
+   * `SNIFF_BIND` exposes a JSON Lines feed of every RTU request/response pair.
+   * `LOG_PATH=-` disables on-disk logging to protect the HA SSD; use the sniff feed instead when you need live visibility.
+
+3. Launch the container from the same directory:
+
+   ```bash
+   docker compose up -d
+   ```
+
+The compose file runs in host networking mode, so the TCP ports above are reachable directly on the HA IP address.
+
+## Using the ports
+
+| Purpose                    | Port | Notes |
+|----------------------------|------|-------|
+| Home Assistant (primary)   | 5020 | Configure HA's Modbus integration to talk to the host IP on this port. |
+| Laptop / dev tools         | 5021 | Use Modbus clients such as `mbpoll`, `pymodbus`, or a second HA instance. |
+| Real-time sniffing (JSONL) | 5700 | Consume with `nc <ha-ip> 5700` or `socat - TCP:<ha-ip>:5700`. |
+
+The sniff stream yields newline-delimited JSON events with timestamps, request metadata, and CRC status. Example:
+
+```json
+{"ts":"2024-04-05T09:30:12.401","role":"REQ","from_client":"TCP:192.168.1.50:55032","uid":1,"func":4,"len":4,"addr":0,"count":2,"crc_ok":true,"hex":"01040000000271cb"}
+{"ts":"2024-04-05T09:30:12.536","role":"RSP","to_client":"TCP:192.168.1.50:55032","uid":1,"func":4,"len":5,"crc_ok":true,"hex":"01040400000000d0f3"}
+```
+
+## Operational notes
+
+* The ShineWiFi thread automatically retries if the dongle is unplugged and announces the state transitions on the sniff stream.
+* All Modbus masters (HA, ShineWiFi, laptop) share a single downstream connection to the inverter. Transactions are serialized
+  with `--min-period 1.0` to match the inverter timing requirements.
+* Because logs are disabled, use the sniff stream for incident response. You can run `nc -k <ha-ip> 5700` on your laptop to keep
+  a rolling view of live traffic.
+
+Stop the container with `docker compose down` when maintenance is required. Update the `.env` file and rerun `docker compose up
+-d` if device paths change.

--- a/growatt_broker/broker.py
+++ b/growatt_broker/broker.py
@@ -8,7 +8,8 @@ Growatt RTU Broker
  - Enforces min request spacing, logs wire traffic
 """
 from __future__ import annotations
-import argparse, socket, threading, time, json, datetime
+import argparse, socket, threading, time, json, datetime, os
+from typing import Iterable, Optional, List
 import serial
 
 
@@ -70,6 +71,18 @@ def now_iso() -> str:
     return datetime.datetime.now().isoformat(timespec="milliseconds")
 
 
+def parse_host_port(spec: str) -> tuple[str, int]:
+    if ":" not in spec:
+        raise ValueError(f"invalid address '{spec}' (expected host:port)")
+    host, port_s = spec.rsplit(":", 1)
+    host = host or "0.0.0.0"
+    try:
+        port = int(port_s)
+    except ValueError as exc:
+        raise ValueError(f"invalid port in '{spec}'") from exc
+    return host, port
+
+
 def parse_rtu(frame: bytes) -> dict:
     if len(frame) < 4:
         return {}
@@ -89,31 +102,106 @@ def parse_rtu(frame: bytes) -> dict:
     return info
 
 
-class WireLogger:
-    def __init__(self, path: str = "/var/log/growatt_broker.jsonl"):
+class EventSink:
+    def handle(self, event: dict) -> None:
+        raise NotImplementedError
+
+
+class EventHub:
+    def __init__(self, sinks: Iterable[EventSink] | None = None):
+        self.sinks: List[EventSink] = list(sinks or [])
+
+    def emit(self, **event) -> None:
+        if not self.sinks:
+            return
+        payload = dict(event)
+        payload.setdefault("ts", now_iso())
+        for sink in list(self.sinks):
+            try:
+                sink.handle(dict(payload))
+            except Exception:
+                # Individual sink failures must not affect the broker loop
+                pass
+
+
+class WireLogger(EventSink):
+    def __init__(self, path: str | None):
         self.path = path
         self._lock = threading.Lock()
-        # Ensure directory and file exist so tail -f works before first event
-        try:
-            import os
-            d = os.path.dirname(self.path) or "."
-            os.makedirs(d, exist_ok=True)
-            with open(self.path, "a", encoding="utf-8"):
+        if self.path and self.path not in {"-", "", "none", "NONE"}:
+            try:
+                d = os.path.dirname(self.path) or "."
+                os.makedirs(d, exist_ok=True)
+                with open(self.path, "a", encoding="utf-8"):
+                    pass
+            except Exception:
                 pass
-        except Exception:
-            # Non-fatal: logging will attempt file creation on first write
-            pass
 
-    def log(self, **event):
-        event["ts"] = now_iso()
+    def enabled(self) -> bool:
+        return bool(self.path) and self.path not in {"-", "", "none", "NONE"}
+
+    def handle(self, event: dict) -> None:
+        if not self.enabled():
+            return
         line = json.dumps(event, ensure_ascii=False)
         with self._lock:
             with open(self.path, "a", encoding="utf-8") as f:
                 f.write(line + "\n")
 
 
+class SnifferRelay(EventSink, threading.Thread):
+    def __init__(self, host: str, port: int):
+        threading.Thread.__init__(self, daemon=True)
+        self.addr = (host, port)
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind(self.addr)
+        self.sock.listen(5)
+        self._clients: List[socket.socket] = []
+        self._lock = threading.Lock()
+
+    def run(self):
+        while True:
+            try:
+                conn, _ = self.sock.accept()
+            except OSError:
+                break
+            conn.setblocking(True)
+            with self._lock:
+                self._clients.append(conn)
+
+    def handle(self, event: dict) -> None:
+        line = json.dumps(event, ensure_ascii=False).encode("utf-8") + b"\n"
+        dead: List[socket.socket] = []
+        with self._lock:
+            clients = list(self._clients)
+        for conn in clients:
+            try:
+                conn.sendall(line)
+            except Exception:
+                dead.append(conn)
+        if dead:
+            with self._lock:
+                for conn in dead:
+                    if conn in self._clients:
+                        self._clients.remove(conn)
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+
+
 class Downstream:
-    def __init__(self, dev: str, baud: int, fmt: str, *, min_cmd_period: float = 1.0, rtimeout: float = 1.5, logger: WireLogger | None = None):
+    def __init__(
+        self,
+        dev: str,
+        baud: int,
+        fmt: str,
+        *,
+        min_cmd_period: float = 1.0,
+        rtimeout: float = 1.5,
+        events: Optional[EventHub] = None,
+    ):
         databits = int(fmt[0]); parity = fmt[1].upper(); stop = int(fmt[2])
         py_par = {'N': serial.PARITY_NONE, 'E': serial.PARITY_EVEN, 'O': serial.PARITY_ODD}[parity]
         py_stp = {1: serial.STOPBITS_ONE, 2: serial.STOPBITS_TWO}[stop]
@@ -125,7 +213,7 @@ class Downstream:
         self.min_cmd_period = float(min_cmd_period)
         self.rtimeout = float(rtimeout)
         self._last_done = 0.0
-        self.logger = logger
+        self.events = events
 
     def _enforce_spacing(self):
         now = time.perf_counter()
@@ -137,36 +225,89 @@ class Downstream:
         with self.lock:
             self._enforce_spacing()
             _ = self.ser.read(self.ser.in_waiting or 0)
-            if self.logger:
-                self.logger.log(role="REQ", from_client=client, crc_ok=crc_ok(req), hex=req.hex(), **parse_rtu(req))
+            if self.events:
+                self.events.emit(role="REQ", from_client=client, crc_ok=crc_ok(req), hex=req.hex(), **parse_rtu(req))
             self.ser.write(req); self.ser.flush()
             resp = self.framer.read_frame(timeout=self.rtimeout)
             self._last_done = time.perf_counter()
-            if self.logger:
-                self.logger.log(role="RSP", to_client=client, crc_ok=crc_ok(resp), hex=(resp.hex() if resp else ""), **parse_rtu(resp or b""))
+            if self.events:
+                self.events.emit(role="RSP", to_client=client, crc_ok=crc_ok(resp), hex=(resp.hex() if resp else ""), **parse_rtu(resp or b""))
             return resp
 
 
 class ShineEndpoint(threading.Thread):
-    def __init__(self, dev: str, baud: int, fmt: str, downstream: Downstream):
+    def __init__(
+        self,
+        dev: str,
+        baud: int,
+        fmt: str,
+        downstream: Downstream,
+        events: Optional[EventHub] = None,
+    ):
         super().__init__(daemon=True)
-        databits = int(fmt[0]); parity = fmt[1].upper(); stop = int(fmt[2])
+        self.dev = dev
+        self.baud = baud
+        self.fmt = fmt
+        self.ds = downstream
+        self.events = events
+        self.ser: Optional[serial.Serial] = None
+        self.framer: Optional[RTUFramer] = None
+        self._online = False
+
+    def _open_port(self) -> None:
+        databits = int(self.fmt[0]); parity = self.fmt[1].upper(); stop = int(self.fmt[2])
         py_par = {'N': serial.PARITY_NONE, 'E': serial.PARITY_EVEN, 'O': serial.PARITY_ODD}[parity]
         py_stp = {1: serial.STOPBITS_ONE, 2: serial.STOPBITS_TWO}[stop]
-        self.ser = serial.Serial(dev, baud, bytesize=databits, parity=py_par, stopbits=py_stp, timeout=0)
+        self.ser = serial.Serial(self.dev, self.baud, bytesize=databits, parity=py_par, stopbits=py_stp, timeout=0)
         bits_per_char = 1 + databits + stop + (0 if parity == 'N' else 1)
-        self.framer = RTUFramer(self.ser, bits_per_char / baud)
-        self.ds = downstream
+        self.framer = RTUFramer(self.ser, bits_per_char / self.baud)
+        self._online = True
+        if self.events:
+            self.events.emit(event="shine_online", role="SYS", port=self.dev, baud=self.baud, fmt=self.fmt)
+
+    def _close_port(self) -> None:
+        if self.ser:
+            try:
+                self.ser.close()
+            except Exception:
+                pass
+        self.ser = None
+        self.framer = None
+        if self._online and self.events:
+            self.events.emit(event="shine_offline", role="SYS", port=self.dev)
+        self._online = False
 
     def run(self):
         while True:
-            req = self.framer.read_frame(timeout=10.0)
-            if not req:
-                continue
-            if len(req) >= 4 and crc_ok(req):
+            if not self.ser or not self.framer:
+                try:
+                    self._open_port()
+                except Exception as exc:
+                    if self.events:
+                        self.events.emit(event="shine_open_failed", role="WARN", port=self.dev, error=str(exc))
+                    time.sleep(5.0)
+                    continue
+            try:
+                req = self.framer.read_frame(timeout=10.0)
+                if not req:
+                    continue
+                if len(req) < 4 or not crc_ok(req):
+                    if self.events:
+                        self.events.emit(role="DROP", from_client="SHINE", reason="bad_crc", hex=req.hex())
+                    continue
                 resp = self.ds.transact(req, client="SHINE")
                 if resp:
                     self.ser.write(resp); self.ser.flush()
+            except (serial.SerialException, OSError) as exc:
+                if self.events:
+                    self.events.emit(event="shine_serial_error", role="WARN", port=self.dev, error=str(exc))
+                self._close_port()
+                time.sleep(2.0)
+            except Exception as exc:
+                if self.events:
+                    self.events.emit(event="shine_unhandled_error", role="ERROR", port=self.dev, error=str(exc))
+                self._close_port()
+                time.sleep(2.0)
 
 
 class TCPServer(threading.Thread):
@@ -233,10 +374,28 @@ def main():
     ap.add_argument("--shine-bytes", default=None, help="Shine format, e.g. 8E1")
     ap.add_argument("--baud", type=int, default=9600, help="Default baud if side-specific not set")
     ap.add_argument("--bytes", default="8E1", help="Default serial format if side-specific not set")
-    ap.add_argument("--tcp", default="0.0.0.0:5020", help="Bind host:port for Modbus-TCP server")
+    ap.add_argument(
+        "--tcp",
+        default="0.0.0.0:5020",
+        help="Bind host:port for primary Modbus-TCP server (use '-' to disable)",
+    )
+    ap.add_argument(
+        "--tcp-alt",
+        default=None,
+        help="Optional secondary Modbus-TCP server for lab/testing (use '-' to disable)",
+    )
+    ap.add_argument(
+        "--sniff",
+        default=None,
+        help="Optional host:port for streaming JSONL sniff feed (use '-' to disable)",
+    )
     ap.add_argument("--min-period", type=float, default=1.0, help="Min seconds between transactions")
     ap.add_argument("--rtimeout", type=float, default=1.5, help="RTU read timeout seconds")
-    ap.add_argument("--log", default="/var/log/growatt_broker.jsonl", help="JSONL log path")
+    ap.add_argument(
+        "--log",
+        default="/var/log/growatt_broker.jsonl",
+        help="JSONL log path (use '-' to disable)",
+    )
     args = ap.parse_args()
 
     inv_baud = args.inv_baud or args.baud
@@ -244,12 +403,69 @@ def main():
     sh_baud = args.shine_baud or args.baud
     sh_bytes = args.shine_bytes or args.bytes
 
-    host, port = args.tcp.split(":"); port = int(port)
-    logger = WireLogger(args.log)
-    ds = Downstream(args.inverter, inv_baud, inv_bytes, min_cmd_period=args.min_period, rtimeout=args.rtimeout, logger=logger)
-    ShineEndpoint(args.shine, sh_baud, sh_bytes, ds).start()
-    TCPServer(host, port, ds).start()
-    print(f"Broker up. INV={args.inverter}@{inv_baud}/{inv_bytes}  SHINE={args.shine}@{sh_baud}/{sh_bytes}  TCP={host}:{port}")
+    sinks: List[EventSink] = []
+    file_logger = WireLogger(args.log)
+    if file_logger.enabled():
+        sinks.append(file_logger)
+
+    sniff_desc = None
+    if args.sniff and args.sniff not in {"", "-"}:
+        try:
+            sniff_host, sniff_port = parse_host_port(args.sniff)
+        except ValueError as exc:
+            ap.error(str(exc))
+        sniffer = SnifferRelay(sniff_host, sniff_port)
+        sniffer.start()
+        sinks.append(sniffer)
+        sniff_desc = f"{sniff_host}:{sniff_port}"
+
+    events = EventHub(sinks)
+
+    ds = Downstream(
+        args.inverter,
+        inv_baud,
+        inv_bytes,
+        min_cmd_period=args.min_period,
+        rtimeout=args.rtimeout,
+        events=events,
+    )
+    shine = ShineEndpoint(args.shine, sh_baud, sh_bytes, ds, events=events)
+    shine.start()
+
+    tcp_specs = []
+    if args.tcp and args.tcp not in {"", "-"}:
+        tcp_specs.append(args.tcp)
+    if args.tcp_alt and args.tcp_alt not in {"", "-"}:
+        tcp_specs.append(args.tcp_alt)
+
+    servers = []
+    tcp_desc = []
+    for spec in tcp_specs:
+        try:
+            host, port = parse_host_port(spec)
+        except ValueError as exc:
+            ap.error(str(exc))
+        server = TCPServer(host, port, ds)
+        server.start()
+        servers.append(server)
+        tcp_desc.append(f"{host}:{port}")
+
+    if not servers:
+        ap.error("at least one TCP server must be configured (set --tcp or --tcp-alt)")
+
+    parts = [
+        f"INV={args.inverter}@{inv_baud}/{inv_bytes}",
+        f"SHINE={args.shine}@{sh_baud}/{sh_bytes}",
+        f"TCP={','.join(tcp_desc)}",
+    ]
+    if sniff_desc:
+        parts.append(f"SNIFF={sniff_desc}")
+    if file_logger.enabled():
+        parts.append(f"LOG={file_logger.path}")
+    else:
+        parts.append("LOG=disabled")
+    print("Broker up. " + "  ".join(parts))
+
     while True:
         time.sleep(3600)
 


### PR DESCRIPTION
## Summary
- add an event hub with optional JSONL file logging, live sniff relay, and reconnection-aware ShineWiFi handling
- support dual Modbus TCP listeners plus a streaming sniff port from the CLI and Docker profile
- document the Home Assistant live deployment profile with 115200 8N1 defaults and port usage guidance

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pymodbus')*

------
https://chatgpt.com/codex/tasks/task_e_68cafd2b181883309d704f27af0ac2f4